### PR TITLE
Add PWM frequency during setup

### DIFF
--- a/examples/dc-torque-voltage/dc-torque-voltage.ino
+++ b/examples/dc-torque-voltage/dc-torque-voltage.ino
@@ -46,6 +46,7 @@ void setup() {
   // if you want, you can limit the voltage used by the driver.
   // This value has to be same as or lower than the power supply voltage.
   driver.voltage_limit = 10.0f;
+  driver.pwm_frequency = 5000;
   // init driver
   driver.init();
   // init sensor


### PR DESCRIPTION
For Voltage torque example, `driver.pwm_frequency = 5000` is missing in setup.
This is needed since frequency is by default null [here](https://github.com/simplefoc/Arduino-FOC-dcmotor/blob/bfa366cd25d303c80ee5637426b83c5029b0f14b/src/drivers/DCDriver2PWM.cpp#L23C14-L23C28)